### PR TITLE
fix: align version with current sdk, publish

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bobanetwork/aa-hc-sdk-contracts",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- bump /contracts to 2.1.0